### PR TITLE
Fix already-existing absence.end_date field on migration `0028`

### DIFF
--- a/wsgi/cnto/cnto/migrations/0028_add_dates_for_dts.py
+++ b/wsgi/cnto/cnto/migrations/0028_add_dates_for_dts.py
@@ -12,17 +12,15 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
+        migrations.AlterField(
             model_name='absence',
             name='end_date',
             field=models.DateField(default=django.utils.timezone.now),
-            preserve_default=False,
         ),
-        migrations.AddField(
+        migrations.AlterField(
             model_name='absence',
             name='start_date',
             field=models.DateField(default=django.utils.timezone.now),
-            preserve_default=False,
         ),
         migrations.AddField(
             model_name='member',


### PR DESCRIPTION
When trying to set up my development environment, I came across an issue with the database migration:

```
Applying cnto.0028_add_dates_for_dts...Traceback (most recent call last):
  File "/home/lastmikoi/.venvs/django-roster/lib/python3.5/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
psycopg2.ProgrammingError: column "end_date" of relation "cnto_absence" already exists
```

This PR fixes the issue by using AlterField rather than AddField, instead of outright removing the operation since the migration `0028` has different default values for that column than what's set in migration `0025`.