### PR TITLE
Upgrade to Python3 and set up Continuous Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .project
 sens_do_not_commit.*
 .pydevproject
+__pycache__

--- a/libs/utils/attendance_scraper.py
+++ b/libs/utils/attendance_scraper.py
@@ -1,6 +1,6 @@
 import traceback
 import logging
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import threading
 
 from django.utils import timezone
@@ -46,7 +46,7 @@ class ScrapeThread(threading.Thread):
                                                       int(scrape_stats["minutes"] * scrape_stats["average_attendance"]),
                                                       int(scrape_stats["minutes"])))
 
-        except Exception, e:
+        except Exception as e:
             self._viewer.show_message_signal.emit("Error", str(traceback.format_exc()))
         self._viewer.busy_signal.emit(False)
 
@@ -68,7 +68,7 @@ def get_all_events_for_page(page_number=1):
     """
     event_url = get_url_for_event_page(page_number)
     LOG.info("Loading all events for page %s...", event_url)
-    page_file = urllib.urlopen(event_url)
+    page_file = urllib.request.urlopen(event_url)
     # page_file = open("temp.html", "r") 
     soup = BeautifulSoup(page_file, "lxml")
 
@@ -165,7 +165,7 @@ def get_attendance_rates_from_event_url(event_url):
     """
     """
     LOG.info("Loading event attendance rates from %s...", event_url)
-    page_file = urllib.urlopen(event_url)
+    page_file = urllib.request.urlopen(event_url)
     # page_file = open("event.html", "r") 
     soup = BeautifulSoup(page_file, "lxml")
 
@@ -276,7 +276,7 @@ if __name__ == "__main__":
     end_dt = datetime(2015, 10, 1, 18, 40, 00)
 
     overall_attendances = get_all_event_attendances_between(start_dt, end_dt)
-    print overall_attendances
+    print(overall_attendances)
     # overall_attendances = {u'Spartak [CNTO - Gnt]': 1.0, u'Chypsa [CNTO - Gnt]': 0.27631578947368424,
     # u'Anders [CNTO - SPC]': 0.7236842105263158, u'Guilly': 0.7236842105263158, u'Hellfire [CNTO - SPC]': 1.0,
     # u'Rush [CNTO - Gnt]': 0.7236842105263158, u'Hateborder [CNTO - Gnt]': 0.7236842105263158, u'Peltier [CNTO -

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-appdirs==1.4.0
 backports.shutil-get-terminal-size==1.0.0
 beautifulsoup4==4.5.3
 decorator==4.0.11
@@ -10,7 +9,6 @@ enum34==1.1.6
 ipython==5.3.0
 ipython-genutils==0.1.0
 lxml==3.7.2
-packaging==16.8
 pathlib2==2.2.1
 pexpect==4.2.1
 pickleshare==0.7.4
@@ -18,12 +16,10 @@ prompt-toolkit==1.0.13
 psycopg2==2.7
 ptyprocess==0.5.1
 Pygments==2.2.0
-pyparsing==2.1.10
 python-valve==0.1.1
 pytz==2016.10
 requests==2.13.0
 scandir==1.5
 simplegeneric==0.8.1
-six==1.10.0
 traitlets==4.3.2
 wcwidth==0.1.7

--- a/wsgi.py
+++ b/wsgi.py
@@ -4,7 +4,7 @@ import os
 virtenv = os.environ['OPENSHIFT_PYTHON_DIR'] + '/virtenv/'
 virtualenv = os.path.join(virtenv, 'bin/activate_this.py')
 try:
-    execfile(virtualenv, dict(__file__=virtualenv))
+    exec(compile(open(virtualenv).read(), virtualenv, 'exec'), dict(__file__=virtualenv))
 except IOError:
     pass
 #

--- a/wsgi/cnto/check_server.py
+++ b/wsgi/cnto/check_server.py
@@ -1,3 +1,3 @@
 from cnto.views.scrape import list_present_players_on_server
 
-print list_present_players_on_server()
+print(list_present_players_on_server())

--- a/wsgi/cnto/cnto/forms.py
+++ b/wsgi/cnto/cnto/forms.py
@@ -5,7 +5,7 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Field, BaseInput
 from crispy_forms.bootstrap import FormActions
 
-from models import Member, MemberGroup, Rank, EventType, Absence, AbsenceType
+from .models import Member, MemberGroup, Rank, EventType, Absence, AbsenceType
 from utils.date_utils import dates_overlap
 
 

--- a/wsgi/cnto/cnto/migrations/0001_initial.py
+++ b/wsgi/cnto/cnto/migrations/0001_initial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0002_event_dts.py
+++ b/wsgi/cnto/cnto/migrations/0002_event_dts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 from django.utils import timezone

--- a/wsgi/cnto/cnto/migrations/0003_event_duration_minutes.py
+++ b/wsgi/cnto/cnto/migrations/0003_event_duration_minutes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0004_unique_member_name.py
+++ b/wsgi/cnto/cnto/migrations/0004_unique_member_name.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0005_more_unique_fields.py
+++ b/wsgi/cnto/cnto/migrations/0005_more_unique_fields.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0006_lower_fieldnames.py
+++ b/wsgi/cnto/cnto/migrations/0006_lower_fieldnames.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0007_event_types.py
+++ b/wsgi/cnto/cnto/migrations/0007_event_types.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0008_event_type_css.py
+++ b/wsgi/cnto/cnto/migrations/0008_event_type_css.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0009_unknown_event_type.py
+++ b/wsgi/cnto/cnto/migrations/0009_unknown_event_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0010_non_null_event_type.py
+++ b/wsgi/cnto/cnto/migrations/0010_non_null_event_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0011_added_join_dt.py
+++ b/wsgi/cnto/cnto/migrations/0011_added_join_dt.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 import django.utils.timezone

--- a/wsgi/cnto/cnto/migrations/0012_verbose_join_date_name.py
+++ b/wsgi/cnto/cnto/migrations/0012_verbose_join_date_name.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 import django.utils.timezone

--- a/wsgi/cnto/cnto/migrations/0013_member_discharged.py
+++ b/wsgi/cnto/cnto/migrations/0013_member_discharged.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0014_absence_data_structures.py
+++ b/wsgi/cnto/cnto/migrations/0014_absence_data_structures.py
@@ -1,5 +1,5 @@
     # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0015_create_basic_absence_types.py
+++ b/wsgi/cnto/cnto/migrations/0015_create_basic_absence_types.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0016_member_deleted.py
+++ b/wsgi/cnto/cnto/migrations/0016_member_deleted.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0017_absence_deleted.py
+++ b/wsgi/cnto/cnto/migrations/0017_absence_deleted.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0018_member_mods_assessed.py
+++ b/wsgi/cnto/cnto/migrations/0018_member_mods_assessed.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0019_member_discharge_dt.py
+++ b/wsgi/cnto/cnto/migrations/0019_member_discharge_dt.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0020_member_email.py
+++ b/wsgi/cnto/cnto/migrations/0020_member_email.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0021_basic_permissions.py
+++ b/wsgi/cnto/cnto/migrations/0021_basic_permissions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0022_add_groups_and_set_permissions.py
+++ b/wsgi/cnto/cnto/migrations/0022_add_groups_and_set_permissions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 from django.contrib.contenttypes.models import ContentType
 
 from django.db import migrations

--- a/wsgi/cnto/cnto/migrations/0023_edit_member_permission_changed.py
+++ b/wsgi/cnto/cnto/migrations/0023_edit_member_permission_changed.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0024_absence_concluded.py
+++ b/wsgi/cnto/cnto/migrations/0024_absence_concluded.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0025_set_default_absence_concluded_state.py
+++ b/wsgi/cnto/cnto/migrations/0025_set_default_absence_concluded_state.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 from django.utils import timezone
@@ -16,7 +16,7 @@ def set_default_absence_concluded_state(apps, schema_editor):
             absence.concluded = True
 
         # Without a save, this migration doesn't actually do anything!
-    print "Done"
+    print("Done")
 
 
 def clear_default_absence_concluded_state(apps, schema_editor):

--- a/wsgi/cnto/cnto/migrations/0026_eventtype_minimum_required_attendance_minutes.py
+++ b/wsgi/cnto/cnto/migrations/0026_eventtype_minimum_required_attendance_minutes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0027_member_names_not_unique.py
+++ b/wsgi/cnto/cnto/migrations/0027_member_names_not_unique.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0028_add_dates_for_dts.py
+++ b/wsgi/cnto/cnto/migrations/0028_add_dates_for_dts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 import django.utils.timezone

--- a/wsgi/cnto/cnto/migrations/0029_copy_dts_to_dates.py
+++ b/wsgi/cnto/cnto/migrations/0029_copy_dts_to_dates.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations
 from django.utils import timezone

--- a/wsgi/cnto/cnto/migrations/0030_remove_dts.py
+++ b/wsgi/cnto/cnto/migrations/0030_remove_dts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0031_membergroup_leader.py
+++ b/wsgi/cnto/cnto/migrations/0031_membergroup_leader.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0032_auto_20151215_1037.py
+++ b/wsgi/cnto/cnto/migrations/0032_auto_20151215_1037.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0033_auto_20151215_1040.py
+++ b/wsgi/cnto/cnto/migrations/0033_auto_20151215_1040.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto/migrations/0034_absencetype_deprecated.py
+++ b/wsgi/cnto/cnto/migrations/0034_absencetype_deprecated.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/wsgi/cnto/cnto/migrations/0035_new_ranks.py
+++ b/wsgi/cnto/cnto/migrations/0035_new_ranks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/wsgi/cnto/cnto/migrations/0036_no_groups_for_discharged.py
+++ b/wsgi/cnto/cnto/migrations/0036_no_groups_for_discharged.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/wsgi/cnto/cnto/migrations/0037_rename_rec_to_rct.py
+++ b/wsgi/cnto/cnto/migrations/0037_rename_rec_to_rct.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/wsgi/cnto/cnto/migrations/0038_rename_rec_to_rct_take2.py
+++ b/wsgi/cnto/cnto/migrations/0038_rename_rec_to_rct_take2.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/wsgi/cnto/cnto/migrations/0039_attendance_attendance_minutes.py
+++ b/wsgi/cnto/cnto/migrations/0039_attendance_attendance_minutes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/wsgi/cnto/cnto/migrations/0040_remove_attendance_attendance.py
+++ b/wsgi/cnto/cnto/migrations/0040_remove_attendance_attendance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/wsgi/cnto/cnto/migrations/0041_member_bqf_assessed.py
+++ b/wsgi/cnto/cnto/migrations/0041_member_bqf_assessed.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/wsgi/cnto/cnto/migrations/0042_member_bi_name.py
+++ b/wsgi/cnto/cnto/migrations/0042_member_bi_name.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import models, migrations
 

--- a/wsgi/cnto/cnto/migrations/0044_auto_20170420_2227.py
+++ b/wsgi/cnto/cnto/migrations/0044_auto_20170420_2227.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cnto', '0043_member_bi_name_verbose_name'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='member',
+            name='bi_name',
+            field=models.TextField(verbose_name='BI nickname'),
+        ),
+        migrations.AlterField(
+            model_name='member',
+            name='discharge_date',
+            field=models.DateField(default=None, verbose_name='Discharge date', null=True),
+        ),
+        migrations.AlterField(
+            model_name='member',
+            name='join_date',
+            field=models.DateField(default=django.utils.timezone.now, verbose_name='Join date'),
+        ),
+    ]

--- a/wsgi/cnto/cnto/models.py
+++ b/wsgi/cnto/cnto/models.py
@@ -57,13 +57,13 @@ class MemberGroup(models.Model):
 class Member(models.Model):
     class Meta:
         permissions = (
-            ("cnto_edit_members", u"Edit members"),
-            ("cnto_view_absentees", u"View absentees"),
-            ("cnto_view_reports", u"View reports"),
-            ("cnto_edit_groups", u"Edit groups"),
-            ("cnto_edit_event_types", u"Edit event types"),
-            ("cnto_view_events", u"View events"),
-            ("cnto_edit_events", u"Edit events"),
+            ("cnto_edit_members", "Edit members"),
+            ("cnto_view_absentees", "View absentees"),
+            ("cnto_view_reports", "View reports"),
+            ("cnto_edit_groups", "Edit groups"),
+            ("cnto_edit_event_types", "Edit event types"),
+            ("cnto_view_events", "View events"),
+            ("cnto_edit_events", "Edit events"),
         )
 
     name = models.TextField(null=False, unique=False)

--- a/wsgi/cnto/cnto/settings.py
+++ b/wsgi/cnto/cnto/settings.py
@@ -10,7 +10,7 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
-import urlparse
+import urllib.parse
 import sys
 
 from socket import gethostname
@@ -144,7 +144,7 @@ from sens_do_not_commit import POSTGRES_DB_URL, POSTGRES_DB_NAME
 
 DATABASES = {}
 if 'OPENSHIFT_MYSQL_DB_URL' in os.environ:
-    url = urlparse.urlparse(os.environ.get('OPENSHIFT_MYSQL_DB_URL'))
+    url = urllib.parse.urlparse(os.environ.get('OPENSHIFT_MYSQL_DB_URL'))
 
     DATABASES['default'] = {
         'ENGINE' : 'django.db.backends.mysql',
@@ -156,7 +156,7 @@ if 'OPENSHIFT_MYSQL_DB_URL' in os.environ:
         }
 
 elif 'OPENSHIFT_POSTGRESQL_DB_URL' in os.environ:
-    url = urlparse.urlparse(os.environ.get('OPENSHIFT_POSTGRESQL_DB_URL'))
+    url = urllib.parse.urlparse(os.environ.get('OPENSHIFT_POSTGRESQL_DB_URL'))
 
     DATABASES['default'] = {
         'ENGINE' : 'django.db.backends.postgresql_psycopg2',
@@ -167,7 +167,7 @@ elif 'OPENSHIFT_POSTGRESQL_DB_URL' in os.environ:
         'PORT': url.port,
         }
 elif POSTGRES_DB_URL is not None:
-    url = urlparse.urlparse(POSTGRES_DB_URL)
+    url = urllib.parse.urlparse(POSTGRES_DB_URL)
 
     DATABASES['default'] = {
         'ENGINE' : 'django.db.backends.postgresql_psycopg2',

--- a/wsgi/cnto/cnto/urls.py
+++ b/wsgi/cnto/cnto/urls.py
@@ -22,7 +22,7 @@ import cnto_users.urls as user_urls
 import cnto_warnings.urls as warning_urls
 import cnto_contributions.urls as contribution_urls
 import cnto_api.urls as api_urls
-from views import scrape, login_user, event, member, report, group, manage, absence
+from .views import scrape, login_user, event, member, report, group, manage, absence
 
 urlpatterns = [
     url(r'^$', RedirectView.as_view(url='/manage/')),

--- a/wsgi/cnto/cnto/views/report.py
+++ b/wsgi/cnto/cnto/views/report.py
@@ -160,7 +160,7 @@ def get_report_context_for_date_range(start_dt, end_dt):
         context["start_dt"] = start_dt.strftime("%Y-%m-%d")
         context["end_dt"] = end_dt.strftime("%Y-%m-%d")
     except Exception:
-        print str(traceback.format_exc())
+        print(str(traceback.format_exc()))
         raise
 
     return context

--- a/wsgi/cnto/cnto/views/scrape.py
+++ b/wsgi/cnto/cnto/views/scrape.py
@@ -126,7 +126,7 @@ def scrape(request, event_type_name, dt_string, start_hour, end_hour):
                                             attendance_seconds=attendance_seconds)
                     attendance.save()
         return JsonResponse({"attendance": scrape_result, "stats": scrape_stats, "success": True})
-    except Exception, e:
+    except Exception as e:
         return JsonResponse({"success": False, "error": traceback.format_exc()})
 
 
@@ -211,7 +211,7 @@ def update_attendance_for_current_event(update_interval_seconds=300, event_type_
                                         attendance_seconds=update_interval_seconds)
                 attendance.save()
         return JsonResponse({"success": True, "error": None})
-    except Exception, e:
+    except Exception as e:
         return JsonResponse({"success": False, "error": traceback.format_exc()})
 
 
@@ -228,4 +228,4 @@ def list_present_players_on_server():
 
 
 if __name__ == "__main__":
-    print "YES"
+    print("YES")

--- a/wsgi/cnto/cnto_contributions/migrations/0001_initial.py
+++ b/wsgi/cnto/cnto_contributions/migrations/0001_initial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto_contributions/migrations/0002_create_contribution_types.py
+++ b/wsgi/cnto/cnto_contributions/migrations/0002_create_contribution_types.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations
 from django.utils import timezone

--- a/wsgi/cnto/cnto_contributions/models.py
+++ b/wsgi/cnto/cnto_contributions/models.py
@@ -12,7 +12,7 @@ class ContributionType(models.Model):
 class Contribution(models.Model):
     class Meta:
         permissions = (
-            ("cnto_edit_contributions", u"Edit contributions"),
+            ("cnto_edit_contributions", "Edit contributions"),
         )
 
     member = models.ForeignKey(Member, null=False)

--- a/wsgi/cnto/cnto_notes/migrations/0001_initial.py
+++ b/wsgi/cnto/cnto_notes/migrations/0001_initial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 import django.utils.timezone

--- a/wsgi/cnto/cnto_notes/migrations/0002_auto_20170420_2227.py
+++ b/wsgi/cnto/cnto_notes/migrations/0002_auto_20170420_2227.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cnto_notes', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='note',
+            name='dt',
+            field=models.DateTimeField(default=django.utils.timezone.now, verbose_name='Note date'),
+        ),
+    ]

--- a/wsgi/cnto/cnto_notes/views.py
+++ b/wsgi/cnto/cnto_notes/views.py
@@ -6,7 +6,7 @@ from django.template.context_processors import csrf
 from cnto.models import Member
 from cnto_notes.forms import NoteForm
 
-from models import Note
+from .models import Note
 
 
 def activate_note(request, pk):
@@ -46,7 +46,7 @@ def delete_note(request, note_pk):
     if not request.user.is_authenticated():
         return redirect("login")
 
-    print "Deleting %s" % (note_pk, )
+    print("Deleting %s" % (note_pk, ))
 
     try:
         note = Note.objects.get(pk=note_pk)

--- a/wsgi/cnto/cnto_warnings/migrations/0001_initial.py
+++ b/wsgi/cnto/cnto_warnings/migrations/0001_initial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 import django.utils.timezone

--- a/wsgi/cnto/cnto_warnings/migrations/0002_general_warning.py
+++ b/wsgi/cnto/cnto_warnings/migrations/0002_general_warning.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 import django.utils.timezone

--- a/wsgi/cnto/cnto_warnings/migrations/0003_add_basic_warning_types.py
+++ b/wsgi/cnto/cnto_warnings/migrations/0003_add_basic_warning_types.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations
 

--- a/wsgi/cnto/cnto_warnings/migrations/0004_memberwarning_notified.py
+++ b/wsgi/cnto/cnto_warnings/migrations/0004_memberwarning_notified.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations, models
 

--- a/wsgi/cnto/cnto_warnings/migrations/0005_add_contribution_warning_types.py
+++ b/wsgi/cnto/cnto_warnings/migrations/0005_add_contribution_warning_types.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations
 

--- a/wsgi/cnto/cnto_warnings/migrations/0006_add_rank_change_warning_types.py
+++ b/wsgi/cnto/cnto_warnings/migrations/0006_add_rank_change_warning_types.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations
 

--- a/wsgi/cnto/cnto_warnings/migrations/0007_add_recruit_low_attendance_warning.py
+++ b/wsgi/cnto/cnto_warnings/migrations/0007_add_recruit_low_attendance_warning.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 from django.db import migrations
 

--- a/wsgi/cnto/cnto_warnings/models.py
+++ b/wsgi/cnto/cnto_warnings/models.py
@@ -68,7 +68,7 @@ class MemberWarning(CreatedModifiedMixin):
             try:
                 recipient_users.append(member_group.leader)
             except User.DoesNotExist:
-                print "Could not find user name %s!" % (self.member.member_group.leader.name,)
+                print("Could not find user name %s!" % (self.member.member_group.leader.name,))
 
         if len(recipient_users) > 0:
             return recipients_to_recipient_string(recipient_users)

--- a/wsgi/cnto/scripts/add_and_update_warnings.py
+++ b/wsgi/cnto/scripts/add_and_update_warnings.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
 
     start_count = MemberWarning.objects.all().count()
 
-    print "Adding and updating warnings..."
+    print("Adding and updating warnings...")
     try:
         allocate_ranks_and_add_warnings_for_previous_cycle()
         add_and_update_low_attendance_for_previous_cycle()
@@ -38,22 +38,22 @@ if __name__ == "__main__":
         add_and_update_grunt_qualification_due()
         add_and_update_contribution_about_to_expire()
         add_absence_monitoring_warnings()
-    except Exception, e:
+    except Exception as e:
         send_exception_email(str(traceback.format_exc()))
         raise
 
     end_count = MemberWarning.objects.all().count()
 
     if start_count < end_count:
-        print "Added %s warnings!" % (end_count - start_count)
+        print("Added %s warnings!" % (end_count - start_count))
     elif end_count < start_count:
-        print "Removed %s warnings!" % (start_count - end_count)
+        print("Removed %s warnings!" % (start_count - end_count))
     else:
-        print "No change to warnings!"
+        print("No change to warnings!")
 
     try:
-        print "Sending emails..."
+        print("Sending emails...")
         send_warning_emails()
-    except Exception, e:
+    except Exception as e:
         send_exception_email(str(traceback.format_exc()))
         raise


### PR DESCRIPTION
* Cleanup of virtualenv-related dependency
* Cleanup of inconsistent state of database migration files
* Pass of the `2to3` tool for migrating the codebase to Python 3.x
* Hotfixes to make the project importable in a CI environment (where `sens_do_not_commit.py` is absent)
* Configuration of the `behave` behavioral testing framework
* Implementation of a trivial user authentication behavioral testing feature
* Configuration of the travis.ci continuous integration service