### PR TITLE
SQL query optimisation passes

### DIFF
--- a/wsgi/cnto/cnto/models.py
+++ b/wsgi/cnto/cnto/models.py
@@ -312,6 +312,19 @@ class Event(models.Model):
     end_dt = models.DateTimeField(null=False)
     duration_minutes = models.IntegerField(null=False)
 
+    def get_stats(self):
+        attendances = self.attendees.all()
+        if len(attendances) > 0:
+            average_attendance = sum([attendance.get_attendance_ratio() for attendance in attendances]) / len(
+                attendances)
+        else:
+            average_attendance = 0
+
+        return {
+            "duration_minutes": self.duration_minutes, "average_attendance": average_attendance,
+            "player_count": len(attendances)
+        }
+
     def lowered_name(self):
         return self.name.lower()
 
@@ -348,26 +361,7 @@ class Absence(models.Model):
 
 
 class Attendance(models.Model):
-    @staticmethod
-    def get_stats_for_event(event):
-        """
-
-        :param event:
-        :return:
-        """
-        attendances = Attendance.objects.filter(event=event)
-        if len(attendances) > 0:
-            average_attendance = sum([attendance.get_attendance_ratio() for attendance in attendances]) / len(
-                attendances)
-        else:
-            average_attendance = 0
-
-        return {
-            "duration_minutes": event.duration_minutes, "average_attendance": average_attendance,
-            "player_count": len(attendances)
-        }
-
-    event = models.ForeignKey(Event, null=False)
+    event = models.ForeignKey(Event, null=False, related_name="attendees")
     member = models.ForeignKey(Member, null=False, related_name="attendances")
     attendance_seconds = models.IntegerField(null=False)
 

--- a/wsgi/cnto/cnto/models.py
+++ b/wsgi/cnto/cnto/models.py
@@ -183,7 +183,7 @@ class Member(models.Model):
 
         :return:
         """
-        attendances = Attendance.objects.filter(member=self)
+        attendances = self.attendances.all()
         return sum([1 if attendance.was_adequate() else 0 for attendance in attendances])
 
     def mod_due_days(self):
@@ -198,7 +198,7 @@ class Member(models.Model):
 
     def is_absent(self):
         current_dt = timezone.now()
-        absences = Absence.objects.filter(deleted=False, concluded=False, member=self,
+        absences = self.absences.filter(deleted=False, concluded=False,
                                           start_date__lte=current_dt.date(),
                                           end_date__gte=current_dt.date())
 
@@ -325,7 +325,7 @@ class AbsenceType(models.Model):
 
 
 class Absence(models.Model):
-    member = models.ForeignKey(Member, null=False)
+    member = models.ForeignKey(Member, null=False, related_name="absences")
     absence_type = models.ForeignKey(AbsenceType, null=False)
 
     start_date = models.DateField(null=False)
@@ -368,7 +368,7 @@ class Attendance(models.Model):
         }
 
     event = models.ForeignKey(Event, null=False)
-    member = models.ForeignKey(Member, null=False)
+    member = models.ForeignKey(Member, null=False, related_name="attendances")
     attendance_seconds = models.IntegerField(null=False)
 
     class Meta:

--- a/wsgi/cnto/cnto/templates/cnto/member/list-discharged.html
+++ b/wsgi/cnto/cnto/templates/cnto/member/list-discharged.html
@@ -17,7 +17,7 @@
         <td>{{ member.rank }}</td>
         <td>{{ member.join_date|date:'Y-m-d' }}</td>
         <td>{{ member.discharge_date|date:'Y-m-d' }}</td>
-        <td>{{ member|active_note_message }}</td>
+        <td>{{ member.notes.all|first }}</td>
         <td>
             <a href="{% url 'edit-note-collection' member.pk %}"><span class="glyphicon glyphicon-pencil"
                                                                         aria-hidden="true"></span></a>

--- a/wsgi/cnto/cnto/templates/cnto/member/list-recruits.html
+++ b/wsgi/cnto/cnto/templates/cnto/member/list-recruits.html
@@ -23,7 +23,7 @@
         <td>{{ recruit|value_of:'events_attended' }}</td>
         <td>{% if recruit.bqf_assessed %}<span class="glyphicon glyphicon-ok">&zwnj;</span>{% endif %}</td>
         <td>{% if recruit|value_of:'ready_for_promotion' %}<span class="glyphicon glyphicon-ok">&zwnj;</span>{% endif %}</td>
-        <td>{{ recruit|active_note_message }}</td>
+        <td>{{ recruit.notes.all|first }}</td>
         <td>
             <a href="{% url 'edit-note-collection' recruit.pk %}"><span class="glyphicon glyphicon-pencil"
                                                                        aria-hidden="true"></span></a>

--- a/wsgi/cnto/cnto/templates/cnto/member/list.html
+++ b/wsgi/cnto/cnto/templates/cnto/member/list.html
@@ -19,7 +19,7 @@
         <td>{{ member.member_group.name }}</td>
         <td>{{ member|contribution_level }}</td>
         <td>{{ member.bi_name }}</td>
-        <td>{{ member|active_note_message }}</td>
+        <td>{{ member.notes.all|first }}</td>
         <td>
             <a href="{% url 'edit-note-collection' member.pk %}"><span class="glyphicon glyphicon-pencil"
                                                                        aria-hidden="true"></span></a>

--- a/wsgi/cnto/cnto/views/event.py
+++ b/wsgi/cnto/cnto/views/event.py
@@ -1,6 +1,7 @@
 import json
 import traceback
 
+from django.db import models
 from django.utils import timezone
 from django.utils.timezone import datetime
 from django.http.response import JsonResponse
@@ -160,8 +161,12 @@ def event_browser(request):
     context = {}
 
     event_data = {}
-    for event in Event.objects.all():
-        stats = Attendance.get_stats_for_event(event)
+    for event in Event.objects.all().select_related(
+        'event_type',
+    ).prefetch_related(
+        models.Prefetch('attendees', queryset=Attendance.objects.all()),
+    ):
+        stats = event.get_stats()
 
         start_dt = event.start_dt
         end_dt = event.end_dt

--- a/wsgi/cnto/cnto_notes/models.py
+++ b/wsgi/cnto/cnto_notes/models.py
@@ -7,7 +7,7 @@ from cnto.models import Member
 
 
 class Note(models.Model):
-    member = models.ForeignKey(Member, null=False)
+    member = models.ForeignKey(Member, null=False, related_name="notes")
     message = models.TextField(null=False)
     dt = models.DateTimeField(verbose_name="Note date", null=False, default=timezone.now)
     active = models.BooleanField(default=True)
@@ -42,4 +42,5 @@ class Note(models.Model):
 
         return final_message
 
-
+    def __str__(self):
+        return self.message

--- a/wsgi/cnto/cnto_warnings/views.py
+++ b/wsgi/cnto/cnto_warnings/views.py
@@ -44,7 +44,10 @@ def list_warnings(request):
         return redirect("manage")
 
     context = {
-        "warnings": MemberWarning.objects.filter(acknowledged=False),
+        "warnings": MemberWarning.objects.filter(acknowledged=False).select_related(
+            'member',
+            'member__member_group',
+        ),
         "warning_count": MemberWarning.objects.filter(acknowledged=False).count()
     }
 


### PR DESCRIPTION
Hello,

I'm gradually dipping back in the RBAC feature project and I had the opportunity of being slowed down to a crawl when using the django debug toolbar.

After a bit of troubleshooting and resolution, turned out it was mainly a query optimisation issue.

Here are the changes and their results, they shouldn't change any feature just make stuff faster, did a tiny bit of refactoring but should be minor.

As far as results are concerned:

`/manage`: Before 915 queries with the current production database, down to 202 queries (couldn't easily optimise absences and contribution types without changing the schema)
`/event-browser`: Before a whopping 6183 queries with the current production database, down to 6 queries :smile: